### PR TITLE
Added Codecov functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ xcode_project: v9/v9.xcodeproj # path to your xcodeproj folder
 xcode_scheme: v9
 
 script:
-  - xcodebuild test \
-    -project v9/v9.xcodeproj \
-    -scheme v9 \
-    -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.2' \
+  - xcodebuild test
+    -project v9/v9.xcodeproj
+    -scheme v9
+    -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.2'
     -enableCodeCoverage YES
     
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,11 @@ xcode_project: v9/v9.xcodeproj # path to your xcodeproj folder
 xcode_scheme: v9
 
 script:
-    xcodebuild test -project v9/v9.xcodeproj -scheme v9 -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.2' CODE_SIGNING_REQUIRED=NO
+  - xcodebuild test \
+    -project v9/v9.xcodeproj \
+    -scheme v9 \
+    -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.2' \
+    -enableCodeCoverage YES
+    
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # FlatLife - A Flat Management App
 [![Build Status](https://travis-ci.org/FlatLife/FlatLife.svg?branch=master)](https://travis-ci.org/FlatLife/FlatLife)
+[![codecov](https://codecov.io/gh/FlatLife/FlatLife/branch/master/graph/badge.svg)](https://codecov.io/gh/FlatLife/FlatLife)
 
 FlatLife is an app for students and others who live in communal living environments. With this application we aim to make it easier and less stressful for people to manage responsibilities such as bills, chores, eating arrangements etc. Having other added features such as a public noticeboard and arranged activities for members of a household to all have access too will give benefits to everyone. 
 


### PR DESCRIPTION
After a successful build in Travis, then Travis will report code coverage details to Codecov. A badge has been added to README.md to quickly see the code coverage percentage and is hyper-linked to the Codecov page for the master branch if you want more details.